### PR TITLE
Add a __version__ and version_info attribute.

### DIFF
--- a/hippylib/__init__.py
+++ b/hippylib/__init__.py
@@ -30,7 +30,7 @@ algorithms for PDE-based deterministic and Bayesian inverse problems.
 """
 from __future__ import absolute_import, division, print_function
 
-version_info = (1, 7, 0, 'dev')
+version_info = (2, 2, 0, 'dev')
 
 __version__ = '.'.join([str(x) for x in version_info])
 

--- a/hippylib/__init__.py
+++ b/hippylib/__init__.py
@@ -30,6 +30,10 @@ algorithms for PDE-based deterministic and Bayesian inverse problems.
 """
 from __future__ import absolute_import, division, print_function
 
+version_info = (1, 7, 0, 'dev')
+
+__version__ = '.'.join([str(x) for x in version_info])
+
 # utils
 from .utils import *
 


### PR DESCRIPTION
This make it slightly easier to dynamically check version.

The __version__ one is relatively classic.
The version_info a bit less, but is s tuple which is easier to compare,
especially in Python 3 as you do not need to take a slice, without it
people usually will start to compare the string, which end up failing
if you ever change one of the version fields to be two digits.