### PR TITLE
Use numpy assertion for better debug.

### DIFF
--- a/hippylib/test/test_gaussian_real_prior.py
+++ b/hippylib/test/test_gaussian_real_prior.py
@@ -134,11 +134,8 @@ class TestGaussianRealPrior(unittest.TestCase):
 
         rel_err = np.linalg.norm(sample_mean - self.means) \
                   / np.linalg.norm(self.means)
-        
-        print('Actual:', sample_mean)
-        print('Expected:', self.means)
-        
-        np.asert_allclose(
+                
+        np.assert_allclose(
                     self.means,
                     sample_mean, 
                     rtol=0.1)

--- a/hippylib/test/test_gaussian_real_prior.py
+++ b/hippylib/test/test_gaussian_real_prior.py
@@ -18,6 +18,8 @@ import dolfin as dl
 import numpy as np
 import scipy.stats as scistat
 
+from numpy.testing import assert_allclose
+
 import sys
 sys.path.append('../../')
 from hippylib import *
@@ -136,11 +138,10 @@ class TestGaussianRealPrior(unittest.TestCase):
         print('Actual:', sample_mean)
         print('Expected:', self.means)
         
-        self.assertTrue(
-                np.allclose(
+        np.asert_allclose(
                     self.means,
                     sample_mean, 
-                    rtol=0.1))
+                    rtol=0.1)
 
     def test_sample_cov(self):
         #Ensure sample cov converges to true cov

--- a/hippylib/test/test_gaussian_real_prior.py
+++ b/hippylib/test/test_gaussian_real_prior.py
@@ -135,7 +135,7 @@ class TestGaussianRealPrior(unittest.TestCase):
         rel_err = np.linalg.norm(sample_mean - self.means) \
                   / np.linalg.norm(self.means)
                 
-        np.assert_allclose(
+        assert_allclose(
                     self.means,
                     sample_mean, 
                     rtol=0.1)


### PR DESCRIPTION
assert_allclose will print debug informations on fail to make it easier
to diagnose error.

This is better that unconditionally printing as some testing framework
do assume that printing output can be an error (for example py.test)