### PR TITLE
Compatibility of nb.py and python3

### DIFF
--- a/hippylib/utils/nb.py
+++ b/hippylib/utils/nb.py
@@ -174,7 +174,7 @@ def show_solution(Vh, ic, state, same_colorbar=True, colorbar=True, mytitle=None
     """
     state.store(ic, 0)
     assert len(times) % 3 == 0
-    nrows = len(times) / 3
+    nrows = int(len(times) / 3)
     subplot_loc = nrows*100 + 30
     plt.figure(figsize=(18,4*nrows))
     
@@ -268,7 +268,7 @@ def plot_eigenvectors(Vh, U, mytitle, which = [0,1,2,5,10,15], cmap = None):
     Plot specified vectors in a :code:MultiVector
     """
     assert len(which) % 3 == 0
-    nrows = len(which) / 3
+    nrows = int(len(which) / 3)
     subplot_loc = nrows*100 + 30
     plt.figure(figsize=(18,4*nrows))
     

--- a/hippylib/utils/nb.py
+++ b/hippylib/utils/nb.py
@@ -173,8 +173,7 @@ def show_solution(Vh, ic, state, same_colorbar=True, colorbar=True, mytitle=None
     Plot a :code:TimeDependentVector at specified time steps
     """
     state.store(ic, 0)
-    assert len(times) % 3 == 0
-    nrows = int(len(times) / 3)
+    nrows = int(np.ceil(len(times) / 3.))
     subplot_loc = nrows*100 + 30
     plt.figure(figsize=(18,4*nrows))
     
@@ -202,12 +201,11 @@ def show_solution(Vh, ic, state, same_colorbar=True, colorbar=True, mytitle=None
     for i in times:
         try:
             state.retrieve(myu.vector(),i)
+            plot(myu, subplot_loc=(subplot_loc+counter), mytitle=title_stamp.format(i), colorbar=colorbar,
+                logscale=logscale, show_axis=show_axis, vmin=vmin, vmax=vmax, cmap = cmap)
+            counter = counter+1
         except:
             print( "Invalid time: ", i)
-            
-        plot(myu, subplot_loc=(subplot_loc+counter), mytitle=title_stamp.format(i), colorbar=colorbar,
-             logscale=logscale, show_axis=show_axis, vmin=vmin, vmax=vmax, cmap = cmap)
-        counter = counter+1
 
     
         
@@ -267,8 +265,7 @@ def plot_eigenvectors(Vh, U, mytitle, which = [0,1,2,5,10,15], cmap = None):
     """
     Plot specified vectors in a :code:MultiVector
     """
-    assert len(which) % 3 == 0
-    nrows = int(len(which) / 3)
+    nrows = int(np.ceil(len(which) / 3.))
     subplot_loc = nrows*100 + 30
     plt.figure(figsize=(18,4*nrows))
     


### PR DESCRIPTION
There are at least two lines in nb.py that seem to assume that division of integers will return an integer. These are  lines 177 and 271 which both read `nrows = len(which) / 3`. For versions of python in which len(which)/3 returns a float there are then subsequent errors in matplotlib calls when `subplot_loc` is not specified as an integer. This is a very simple pull request in which `nrows` will now be explicitly cast to an integer.