### PR TITLE
Added function for computing vector-valued BiLaplacian Prior

### DIFF
--- a/hippylib/modeling/__init__.py
+++ b/hippylib/modeling/__init__.py
@@ -20,7 +20,7 @@ from .pointwiseObservation import assemblePointwiseObservation, exportPointwiseO
 from .timeDependentVector import TimeDependentVector
 
 from .PDEProblem import PDEProblem, PDEVariationalProblem
-from .prior import _Prior, LaplacianPrior, SqrtPrecisionPDE_Prior, BiLaplacianPrior, MollifiedBiLaplacianPrior, GaussianRealPrior, BiLaplacianComputeCoefficients
+from .prior import _Prior, LaplacianPrior, SqrtPrecisionPDE_Prior, BiLaplacianPrior, MollifiedBiLaplacianPrior, GaussianRealPrior, BiLaplacianComputeCoefficients, VectorBiLaplacianPrior
 from .misfit import Misfit, ContinuousStateObservation, DiscreteStateObservation, MultDiscreteStateObservation, MultiStateMisfit, PointwiseStateObservation, MultPointwiseStateObservation
 from .model import Model
 from .modelVerify import modelVerify


### PR DESCRIPTION
Function allows for creating BiLaplacian priors for vector-valued distributions, where each component of the vector has a BiLaplacian covariance matrix with different pointwise variance and correlation length. 