### PR TITLE
Fixed typo in sampling uniform distribution with PETScVector [random-fix]

### DIFF
--- a/hippylib/utils/random.py
+++ b/hippylib/utils/random.py
@@ -62,7 +62,7 @@ class Random(cpp_module.Random):
                 super(Random, self).uniform(out.data[i], a,b)
             return None
         elif type( dl.as_backend_type(out) ) is dl.PETScVector:
-            super(Random, self).uniform(out[i], a,b)
+            super(Random, self).uniform(out, a,b)
             return None
     
     def normal(self, sigma, out=None):


### PR DESCRIPTION
Fixing a small bug causing an error when sampling from a uniform distribution in `hp.Random` when using a `dl.PETScVector` as the output.